### PR TITLE
Fix BuildManager exception during load

### DIFF
--- a/_BuildManager/_BuildManager.cs
+++ b/_BuildManager/_BuildManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -40,7 +40,10 @@ namespace _BuildManager
         {
             Assembly buildManager = Assembly.GetExecutingAssembly();
             String location = Path.GetDirectoryName(buildManager.Location);
-            List<AssemblyName> assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(x => Path.GetDirectoryName(x.Location) == location).Select(x => x.GetName()).ToList();
+            List<AssemblyName> assemblies = AppDomain.CurrentDomain.GetAssemblies()
+                .Where(x => !x.IsDynamic)
+                .Where(x => Path.GetDirectoryName(x.Location) == location)
+                .Select(x => x.GetName()).ToList();
 
             String versionInfo = "[BLACKRACK_EVE_REDUX] Version Info:\n";
             foreach (AssemblyName assembly in assemblies)


### PR DESCRIPTION
Turns out there's a StackOverflow post on this exact situation: https://stackoverflow.com/questions/44446720/notsupportedexception-the-invoked-member-is-not-supported-in-a-dynamic-module-i/44446796

Closes #6.